### PR TITLE
fix: show active state in overlay without visible tools

### DIFF
--- a/src/office/components/ToolOverlay.tsx
+++ b/src/office/components/ToolOverlay.tsx
@@ -39,6 +39,10 @@ function getActivityText(
     }
   }
 
+  // Some agents/residents only emit lifecycle/assistant activity and may not
+  // surface nested tool events to this overlay. Still reflect active work.
+  if (isActive) return 'Thinking...';
+
   return 'Idle';
 }
 
@@ -118,13 +122,12 @@ export function ToolOverlay({
         // Determine dot color
         const tools = agentTools[id];
         const hasPermission = subHasPermission || tools?.some((t) => t.permissionWait && !t.done);
-        const hasActiveTools = tools?.some((t) => !t.done);
         const isActive = ch.isActive;
 
         let dotColor: string | null = null;
         if (hasPermission) {
           dotColor = 'var(--pixel-status-permission)';
-        } else if (isActive && hasActiveTools) {
+        } else if (isActive) {
           dotColor = 'var(--pixel-status-active)';
         }
 


### PR DESCRIPTION
## Summary
- show `Thinking...` when the agent is active but no visible tool event is present
- keep the blue active dot driven by `isActive` even when the tool list has no pending item
- preserve permission precedence for the yellow approval state

## Context
This fixes issue #3, where resident/subagent activity could stay stuck on `Idle` with no blue dot because some flows only emit lifecycle/assistant activity and do not surface nested tool events to the overlay.

## Validation
- attempted `npm run build`, but local dependencies are not installed in this checkout (`tsc: not found`)

Closes #3