### PR TITLE
Fix login websocket timing and resident visibility when bridge is offline

### DIFF
--- a/server.js
+++ b/server.js
@@ -127,6 +127,7 @@ httpServer.on('upgrade', (req, socket, head) => {
 
 let clients = [];
 let currentAgentId = 1;
+let bridgeStatus = 'connecting';
 
 // ── Resident session definitions ──────────────────────────────────────────────
 // These always appear in the office, even before any OpenClaw event arrives.
@@ -186,13 +187,9 @@ wss.on('connection', (ws) => {
   console.log('Browser client connected');
   clients.push(ws);
 
-  // If OpenClaw is already connected, immediately announce all residents to this new client
-  if (openclawReady) {
-    for (const r of RESIDENTS) {
-      ws.send(JSON.stringify({ type: 'agentCreated', id: r.id, name: r.name, sessionKey: r.sessionKey, resident: true }));
-      ws.send(JSON.stringify({ type: 'agentStatus', id: r.id, status: 'idle' }));
-    }
-  }
+  // Always announce residents so the office is populated even while the bridge reconnects.
+  sendResidents(ws);
+  sendBridgeStatus(bridgeStatus, ws);
 
   ws.on('message', (message) => {
     try {
@@ -226,6 +223,30 @@ wss.on('connection', (ws) => {
 function broadcast(msg) {
   const raw = JSON.stringify(msg);
   clients.forEach(c => { if (c.readyState === 1) c.send(raw); });
+}
+
+function sendResidents(target = null) {
+  const payloads = RESIDENTS.flatMap((r) => [
+    { type: 'agentCreated', id: r.id, name: r.name, sessionKey: r.sessionKey, resident: true },
+    { type: 'agentStatus', id: r.id, status: 'idle' },
+  ]);
+  if (target) {
+    for (const msg of payloads) {
+      if (target.readyState === WebSocket.OPEN) target.send(JSON.stringify(msg));
+    }
+    return;
+  }
+  for (const msg of payloads) broadcast(msg);
+}
+
+function sendBridgeStatus(status, target = null) {
+  bridgeStatus = status;
+  const msg = { type: 'wsConnectionStatus', status };
+  if (target) {
+    if (target.readyState === WebSocket.OPEN) target.send(JSON.stringify(msg));
+    return;
+  }
+  broadcast(msg);
 }
 
 // ── Tool name → UI label mapping ─────────────────────────────────────────────
@@ -290,6 +311,7 @@ function openclawSend(obj) {
 
 function connectToOpenClaw() {
   console.log(`[OpenClaw] Connecting to ${OPENCLAW_WS_URL}...`);
+  sendBridgeStatus('connecting');
   openclawWs = new WebSocket(OPENCLAW_WS_URL);
 
   openclawWs.on('message', (data) => {
@@ -332,19 +354,18 @@ function connectToOpenClaw() {
     // ── hello-ok ──
     if (msg.type === 'res' && msg.ok && msg.payload?.type === 'hello-ok') {
       openclawReady = true;
+      sendBridgeStatus('connected');
       const v = msg.payload.server?.version;
       console.log(`[OpenClaw] Connected! Server ${v}, protocol ${msg.payload.protocol}`);
 
-      // Announce all resident agents to the UI
-      for (const r of RESIDENTS) {
-        broadcast({ type: 'agentCreated', id: r.id, name: r.name, sessionKey: r.sessionKey, resident: true });
-        broadcast({ type: 'agentStatus', id: r.id, status: 'idle' });
-      }
+      // Re-announce residents in case clients connected before the bridge was ready.
+      sendResidents();
       return;
     }
 
     // ── connect error ──
     if (msg.type === 'res' && !msg.ok && !openclawReady) {
+      sendBridgeStatus('disconnected');
       console.error('[OpenClaw] Connect failed:', msg.error?.message, msg.error?.details);
       return;
     }
@@ -408,11 +429,13 @@ function connectToOpenClaw() {
   openclawWs.on('error', (e) => {
     console.error('[OpenClaw] Error:', e.message);
     openclawReady = false;
+    sendBridgeStatus('disconnected');
   });
 
   openclawWs.on('close', (code, reason) => {
     console.log(`[OpenClaw] Disconnected (${code}) — reconnecting in 5s...`);
     openclawReady = false;
+    sendBridgeStatus('disconnected');
     setTimeout(connectToOpenClaw, 5000);
   });
 }
@@ -476,7 +499,7 @@ if (process.env.NODE_ENV === 'production') {
   const distDir = path.join(__dirname, 'dist');
   app.use(express.static(distDir));
   // SPA fallback — any non-API route serves index.html
-  app.get('*', (req, res) => {
+  app.get('/{*path}', (req, res) => {
     if (req.path.startsWith('/api/')) return res.status(404).json({ error: 'Not found' });
     res.sendFile(path.join(distDir, 'index.html'));
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -503,7 +503,7 @@ function App() {
             zoom={editor.zoom}
             panRef={editor.panRef}
             subagentCharacters={subagentCharacters}
-            selectedChatAgentId={selectedChatAgentId}
+            selectedChatAgentId={selectedChatAgentId ?? undefined}
           />
         )}
 

--- a/src/browserMock.ts
+++ b/src/browserMock.ts
@@ -273,7 +273,20 @@ export function dispatchMockMessages(): void {
   if (!(window as any).__pixel_ws_connected) {
     (window as any).__pixel_ws_connected = true;
 
-    function connectWs() {
+    async function connectWs() {
+      try {
+        const auth = await fetch('/api/auth/check', { credentials: 'include' }).then((r) => r.json());
+        if (!auth?.ok) {
+          dispatch({ type: 'wsConnectionStatus', status: 'disconnected' });
+          setTimeout(() => { void connectWs(); }, 5000);
+          return;
+        }
+      } catch {
+        dispatch({ type: 'wsConnectionStatus', status: 'disconnected' });
+        setTimeout(() => { void connectWs(); }, 5000);
+        return;
+      }
+
       const wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       // In dev, Vite proxies /ws → localhost:3000/ws. In production, same host/port.
       const wsUrl = `${wsProto}//${window.location.host}/ws`;
@@ -296,7 +309,7 @@ export function dispatchMockMessages(): void {
 
       ws.onclose = () => {
         dispatch({ type: 'wsConnectionStatus', status: 'disconnected' });
-        setTimeout(connectWs, 5000);
+        setTimeout(() => { void connectWs(); }, 5000);
       };
 
       (window as any).__pixel_ws = ws;
@@ -304,7 +317,7 @@ export function dispatchMockMessages(): void {
 
     // Dispatch connecting status before first attempt
     dispatch({ type: 'wsConnectionStatus', status: 'connecting' });
-    connectWs();
+    void connectWs();
 
     // Listen for user input on UI and send it to the backend process
     window.addEventListener('message', (e) => {

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -45,7 +45,7 @@ export function TerminalPanel({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const dot = STATUS_DOT[wsStatus];
   const activeTab = agentTabs.find((t) => t.id === selectedChatAgentId);
-  const activeColor = activeTab?.color ?? agentColor(selectedChatAgentId);
+  const activeColor = activeTab?.color ?? agentColor(selectedChatAgentId ?? 1);
   const activeName = activeTab?.name ?? 'OpenClaw';
 
   useEffect(() => {

--- a/src/hooks/useExtensionMessages.ts
+++ b/src/hooks/useExtensionMessages.ts
@@ -87,6 +87,7 @@ export function useExtensionMessages(
   const [loadedAssets, setLoadedAssets] = useState<
     { catalog: FurnitureAsset[]; sprites: Record<string, string[][]> } | undefined
   >();
+  const [, setWorkspaceFolders] = useState<WorkspaceFolder[]>([]);
   const [alwaysShowLabels, setAlwaysShowLabels] = useState(false);
 
   // Track whether initial layout has been loaded (ref to avoid re-render)

--- a/test/dev-assets.test.ts
+++ b/test/dev-assets.test.ts
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'node:url';
 import type { ViteDevServer } from 'vite';
 import { createServer } from 'vite';
 
-import type { AssetIndex, CatalogEntry } from '../../shared/assets/types.ts';
+import type { AssetIndex, CatalogEntry } from '../shared/assets/types.ts';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 


### PR DESCRIPTION
## Summary
This PR collects the minimal fixes that were validated locally while deploying/testing `openclaw-office-web` on the Jarvis host.

It addresses two concrete runtime problems:
1. the browser was trying to open `/ws` before login, causing repeated WebSocket failures on the login screen;
2. resident characters could remain invisible when the backend bridge to OpenClaw was not ready, leaving the office visually empty even though login worked.

## What changed
### Frontend
- gate WebSocket connection in `src/browserMock.ts` behind `/api/auth/check`
- only open `/ws` after an authenticated session exists
- keep retry behavior, but without spamming upgrade failures on the login screen

### Backend / bridge UX
- always announce resident agents on browser connection, even while the OpenClaw bridge is still connecting/reconnecting
- broadcast bridge status (`connecting` / `connected` / `disconnected`) based on real backend bridge state
- re-announce residents when the OpenClaw bridge becomes ready

### Build/runtime fixes included
- Express 5 SPA fallback compatibility in `server.js`
- small TypeScript/build/test fixes already validated locally:
  - optional prop compatibility in `src/App.tsx`
  - null guard in `src/components/TerminalPanel.tsx`
  - state reference cleanup in `src/hooks/useExtensionMessages.ts`
  - fixed test import path in `test/dev-assets.test.ts`

## Why
### 1) Login screen WebSocket failures
Before this PR, the frontend attempted `ws://.../ws` immediately on page load.
The server correctly rejects websocket upgrade without a valid session cookie, so the login page spammed:
- `WebSocket connection to 'ws://.../ws' failed`

### 2) Missing resident characters
Characters are created from `agentCreated` events.
The previous server behavior only announced residents when `openclawReady === true`.
So if login worked but the backend bridge to OpenClaw was broken or not paired, the office loaded with no characters.

This PR makes the office populate residents immediately and report bridge state honestly, while still leaving real OpenClaw functionality dependent on the actual backend connection.

## Validation
Locally validated with:
- `npm run build` ✅
- login flow analysis against `/api/login` + `/api/auth/check`
- websocket handshake behavior checked with/without session

## Still NOT solved here
This PR improves runtime correctness and UX, but it does **not** by itself solve backend connectivity to OpenClaw.
Operational issues may still remain, such as:
- `OPENCLAW_URL` pointing to an address the container cannot resolve/reach
- `PAIRING_REQUIRED / not-paired`

Those should be handled separately in deployment/configuration.
